### PR TITLE
Make Alnuth compatible with PARI 2.9.0

### DIFF
--- a/gp/polyfactors.gp
+++ b/gp/polyfactors.gp
@@ -3,16 +3,7 @@ f = subst(f,variable(f),'varA);
 pol = Pol(vector(#coeffs-1,i,Polrev(coeffs[i],'varA)));
 n = poldegree(f);
 gettime();
-{
-  if(type(version)!="t_POL" && lex(version(),[2,4,3])>=0,
-    fac = lift(nffactor(f, pol ))
-  , if(poldegree(pol)*3<n,
-      fac = lift(factornf(pol,f));
-    ,
-      nf = nfinit([f, nfbasis(f,1)]);
-      fac = lift(nffactor(nf, pol ))
-  ));
-}
+fac = lift(nffactor(f, pol ));
 zeit = gettime();
 
 p2v(n,b)=vector(n,j,polcoeff(b,j-1));


### PR DESCRIPTION
This removes support for PARI < 2.4.3 which allows PARI 2.9.0 to
parse the code (PARI 2.4.3 was released in 08/10/2010).

This is the most urgent part of #1.