### PR TITLE
set `IsFinite` in `FieldByMatrices` to `false`

### DIFF
--- a/gap/matfield.gi
+++ b/gap/matfield.gi
@@ -184,6 +184,7 @@ InstallGlobalFunction( FieldByMatricesNC, function( gens )
     F := FieldByGenerators( gens);
     SetIsNumberField( F, true );
     SetIsNumberFieldByMatrices( F, true );
+    SetIsFinite( F, false );
     return F;
 end );  
 

--- a/tst/ALNUTH.tst
+++ b/tst/ALNUTH.tst
@@ -4,6 +4,8 @@ gap> F := FieldByMatrices( mats );
 <rational matrix field of degree 4>
 gap> DegreeOverPrimeField( F );
 4
+gap> IsFinite( F );
+false
 gap> EquationOrderBasis( F );
 Basis( <rational matrix field of degree 4>, 
 [ [ [ 1, 0, 0, 0 ], [ 0, 1, 0, 0 ], [ 0, 0, 1, 0 ], [ 0, 0, 0, 1 ] ], 


### PR DESCRIPTION
This is just a workaround, see oscar-system/Oscar.jl/pull/2254.

The real problem seems to be that the `LeftActingDomain` attribute `F` of a field `K` of matrices is another field of matrices (why not simply `Rationals`?) which does not behave nicely. For example, `F = K` runs into an error.